### PR TITLE
Feature/regfile refactoring

### DIFF
--- a/mips_datapath.vhd
+++ b/mips_datapath.vhd
@@ -12,11 +12,6 @@ entity datapath is  -- MIPS datapath
        aluout: buffer STD_LOGIC_VECTOR(31 downto 0);
        ula_source_1         in STD_LOGIC_VECTOR(31 downto 0);
        ula_source_2         in STD_LOGIC_VECTOR(31 downto 0));
-       
-       we3:           in  STD_LOGIC;
-         ra1, ra2, wa3: in  STD_LOGIC_VECTOR(4 downto 0);
-         wd3:           in  STD_LOGIC_VECTOR(31 downto 0);
-         rd1, rd2:      out STD_LOGIC_VECTOR(31 downto 0));
 end;
 
 architecture struct of datapath is
@@ -25,14 +20,6 @@ architecture struct of datapath is
          alucontrol: in  STD_LOGIC_VECTOR(2 downto 0);
          result:     buffer STD_LOGIC_VECTOR(31 downto 0);
          zero:       out STD_LOGIC);
-  end component;
-
-  component regfile
-    port(clk:           in  STD_LOGIC;
-         we3:           in  STD_LOGIC;
-         ra1, ra2, wa3: in  STD_LOGIC_VECTOR(4 downto 0);
-         wd3:           in  STD_LOGIC_VECTOR(31 downto 0);
-         rd1, rd2:      out STD_LOGIC_VECTOR(31 downto 0));
   end component;
 
   component adder
@@ -78,6 +65,7 @@ begin
   pcbrmux: mux2 generic map(32) port map(pcplus4, pcbranch, 
                                          pcsrc, pcnextbr);
   pcmux: mux2 generic map(32) port map(pcnextbr, pcjump, jump, pcnext);
+
 
   se: signext port map(instr(15 downto 0), signimm);
 

--- a/mips_datapath.vhd
+++ b/mips_datapath.vhd
@@ -4,13 +4,19 @@ entity datapath is  -- MIPS datapath
   port(clk, reset:        in  STD_LOGIC;
        memtoreg, pcsrc:   in  STD_LOGIC;
        alusrc, regdst:    in  STD_LOGIC;
-       regwrite, jump:    in  STD_LOGIC;
+       jump:              in  STD_LOGIC;
        alucontrol:        in  STD_LOGIC_VECTOR(2 downto 0);
        zero:              out STD_LOGIC;
        pc:                buffer STD_LOGIC_VECTOR(31 downto 0);
        instr:             in  STD_LOGIC_VECTOR(31 downto 0);
-       aluout, writedata: buffer STD_LOGIC_VECTOR(31 downto 0);
-       readdata:          in  STD_LOGIC_VECTOR(31 downto 0));
+       aluout: buffer STD_LOGIC_VECTOR(31 downto 0);
+       ula_source_1         in STD_LOGIC_VECTOR(31 downto 0);
+       ula_source_2         in STD_LOGIC_VECTOR(31 downto 0));
+       
+       we3:           in  STD_LOGIC;
+         ra1, ra2, wa3: in  STD_LOGIC_VECTOR(4 downto 0);
+         wd3:           in  STD_LOGIC_VECTOR(31 downto 0);
+         rd1, rd2:      out STD_LOGIC_VECTOR(31 downto 0));
 end;
 
 architecture struct of datapath is
@@ -19,6 +25,14 @@ architecture struct of datapath is
          alucontrol: in  STD_LOGIC_VECTOR(2 downto 0);
          result:     buffer STD_LOGIC_VECTOR(31 downto 0);
          zero:       out STD_LOGIC);
+  end component;
+
+  component regfile
+    port(clk:           in  STD_LOGIC;
+         we3:           in  STD_LOGIC;
+         ra1, ra2, wa3: in  STD_LOGIC_VECTOR(4 downto 0);
+         wd3:           in  STD_LOGIC_VECTOR(31 downto 0);
+         rd1, rd2:      out STD_LOGIC_VECTOR(31 downto 0));
   end component;
 
   component adder
@@ -48,12 +62,11 @@ architecture struct of datapath is
          y:      out STD_LOGIC_VECTOR(width-1 downto 0));
   end component;
 
-  signal writereg:           STD_LOGIC_VECTOR(4 downto 0);
   signal pcjump, pcnext, 
          pcnextbr, pcplus4, 
          pcbranch:           STD_LOGIC_VECTOR(31 downto 0);
   signal signimm, signimmsh: STD_LOGIC_VECTOR(31 downto 0);
-  signal srca, srcb, result: STD_LOGIC_VECTOR(31 downto 0);
+  signal src1, src2, result: STD_LOGIC_VECTOR(31 downto 0);
   
 begin
   -- next PC logic
@@ -66,21 +79,12 @@ begin
                                          pcsrc, pcnextbr);
   pcmux: mux2 generic map(32) port map(pcnextbr, pcjump, jump, pcnext);
 
-  -- register file logic
-  rf: regfile port map(clk, regwrite, instr(25 downto 21), 
-                       instr(20 downto 16), writereg, result, srca, 
-				writedata);
-  wrmux: mux2 generic map(5) port map(instr(20 downto 16), 
-                                      instr(15 downto 11), 
-                                      regdst, writereg);
-  resmux: mux2 generic map(32) port map(aluout, readdata, 
-                                        memtoreg, result);
   se: signext port map(instr(15 downto 0), signimm);
 
   -- ALU logic
-  srcbmux: mux2 generic map(32) port map(writedata, signimm, alusrc, 
-                                         srcb);
-  mainalu: alu port map(srca, srcb, alucontrol, aluout, zero);
+  srcbmux: mux2 generic map(32) port map(ula_source_2, signimm, alusrc, 
+                                         src2);
+  mainalu: alu port map(src1, src2, alucontrol, aluout, zero);
 end;
 
 library IEEE; use IEEE.STD_LOGIC_1164.all; 

--- a/mips_datapath.vhd
+++ b/mips_datapath.vhd
@@ -10,8 +10,8 @@ entity datapath is  -- MIPS datapath
        pc:                buffer STD_LOGIC_VECTOR(31 downto 0);
        instr:             in  STD_LOGIC_VECTOR(31 downto 0);
        aluout: buffer STD_LOGIC_VECTOR(31 downto 0);
-       ula_source_1         in STD_LOGIC_VECTOR(31 downto 0);
-       ula_source_2         in STD_LOGIC_VECTOR(31 downto 0));
+       ula_source_1:         in STD_LOGIC_VECTOR(31 downto 0);
+       ula_source_2:         in STD_LOGIC_VECTOR(31 downto 0));
 end;
 
 architecture struct of datapath is
@@ -110,7 +110,7 @@ end;
 
 architecture behave of signext is
 begin
-  y <= X"ffff" & a when a(15) else X"0000" & a; 
+ -- y <= X"ffff" & a when a(15) else X"0000" & a; 
 end;
 
 library IEEE; use IEEE.STD_LOGIC_1164.all;  use IEEE.STD_LOGIC_ARITH.all;

--- a/mips_datapath.vhd
+++ b/mips_datapath.vhd
@@ -21,14 +21,6 @@ architecture struct of datapath is
          zero:       out STD_LOGIC);
   end component;
 
-  component regfile
-    port(clk:           in  STD_LOGIC;
-         we3:           in  STD_LOGIC;
-         ra1, ra2, wa3: in  STD_LOGIC_VECTOR(4 downto 0);
-         wd3:           in  STD_LOGIC_VECTOR(31 downto 0);
-         rd1, rd2:      out STD_LOGIC_VECTOR(31 downto 0));
-  end component;
-
   component adder
     port(a, b: in  STD_LOGIC_VECTOR(31 downto 0);
          y:    out STD_LOGIC_VECTOR(31 downto 0));

--- a/mipsc.vhd
+++ b/mipsc.vhd
@@ -54,6 +54,7 @@ architecture test of testbench is
   entity top is -- top-level design for testing
     port(clk, reset:           in     STD_LOGIC;
          writedata, dataadr:   buffer STD_LOGIC_VECTOR(31 downto 0);
+         ula_source_1, ula_source_2:   in STD_LOGIC_VECTOR(31 downto 0);
          memwrite:             buffer STD_LOGIC);
   end;
   
@@ -97,6 +98,7 @@ architecture test of testbench is
          instr:             in  STD_LOGIC_VECTOR(31 downto 0);
          memwrite:          out STD_LOGIC;
          aluout, writedata: out STD_LOGIC_VECTOR(31 downto 0);
+         ula_source_1, ula_source_2:   in STD_LOGIC_VECTOR(31 downto 0);
          readdata:          in  STD_LOGIC_VECTOR(31 downto 0));
   end;
   
@@ -114,13 +116,14 @@ architecture test of testbench is
       port(clk, reset:        in  STD_LOGIC;
            memtoreg, pcsrc:   in  STD_LOGIC;
            alusrc, regdst:    in  STD_LOGIC;
-           regwrite, jump:    in  STD_LOGIC;
+           jump:    in  STD_LOGIC;
            alucontrol:        in  STD_LOGIC_VECTOR(2 downto 0);
            zero:              out STD_LOGIC;
            pc:                buffer STD_LOGIC_VECTOR(31 downto 0);
            instr:             in STD_LOGIC_VECTOR(31 downto 0);
-           aluout, writedata: buffer STD_LOGIC_VECTOR(31 downto 0);
-           readdata:          in  STD_LOGIC_VECTOR(31 downto 0));
+           aluout: buffer STD_LOGIC_VECTOR(31 downto 0);
+           ula_source_1:          in  STD_LOGIC_VECTOR(31 downto 0);
+           ula_source_2:          in  STD_LOGIC_VECTOR(31 downto 0));
     end component;
     signal memtoreg, alusrc, regdst, regwrite, jump, pcsrc: STD_LOGIC;
     signal zero: STD_LOGIC;
@@ -130,6 +133,6 @@ architecture test of testbench is
                               zero, memtoreg, memwrite, pcsrc, alusrc,
                               regdst, regwrite, jump, alucontrol);
     dp: datapath port map(clk, reset, memtoreg, pcsrc, alusrc, regdst,
-                          regwrite, jump, alucontrol, zero, pc, instr,
-                          aluout, writedata, readdata);
+                          jump, alucontrol, zero, pc, instr,
+                          aluout, ula_source_1, ula_source_2);
   end;

--- a/mipsc.vhd
+++ b/mipsc.vhd
@@ -9,15 +9,17 @@ architecture test of testbench is
   component top
     port(clk, reset:           in  STD_LOGIC;
          writedata, dataadr:   out STD_LOGIC_VECTOR(31 downto 0);
+         ula_source_1, ula_source_2:   in STD_LOGIC_VECTOR(31 downto 0);
          memwrite:             out STD_LOGIC);
   end component;
-  signal writedata, dataadr:    STD_LOGIC_VECTOR(31 downto 0);
-  signal clk, reset,  memwrite: STD_LOGIC;
+  signal writedata, dataadr:         STD_LOGIC_VECTOR(31 downto 0);
+  signal ula_source_1, ula_source_2: STD_LOGIC_VECTOR(31 downto 0);
+  signal clk, reset,  memwrite:      STD_LOGIC;
   
   begin
   
     -- instantiate device to be tested
-    dut: top port map(clk, reset, writedata, dataadr, memwrite);
+    dut: top port map(clk, reset, writedata, dataadr, ula_source_1, ula_source_2, memwrite);
   
     -- Generate clock with 10 ns period
     process begin
@@ -65,6 +67,7 @@ architecture test of testbench is
            instr_A, instr_B, instr_C: in  STD_LOGIC_VECTOR(31 downto 0);
            memwrite:                  out STD_LOGIC;
            aluout, writedata:         out STD_LOGIC_VECTOR(31 downto 0);
+           ula_source_1, ula_source_2: in STD_LOGIC_VECTOR(31 downto 0);
            readdata:                  in  STD_LOGIC_VECTOR(31 downto 0));
     end component;
 
@@ -84,27 +87,29 @@ architecture test of testbench is
 
   begin
     -- instantiate processor and memories
-    mips1: mips port map(clk, reset, pc, instr, memwrite, dataadr, 
-                         writedata, readdata);
-    imem1: imem port map(pc(7 downto 2), instr_A, instr_B, instr_C); -- pc(7 downto 2) is a way of limiting the number of instructions read from the instruction memory
-    dmem1: dmem port map(clk, memwrite, dataadr, writedata, readdata);
+    mips1: mips port map(clk, reset, pc, instr_A, instr_B, instr_C, memwrite, dataadr, 
+                         writedata, ula_source_1, ula_source_2, readdata);
+    imem1: Instruction_Memory port map(pc(7 downto 2), instr_A, instr_B, instr_C); -- pc(7 downto 2) is a way of limiting the number of instructions read from the instruction memory
+    dmem1: Data_Memory port map(clk, memwrite, dataadr, writedata, readdata);
   end;
   
   library IEEE; use IEEE.STD_LOGIC_1164.all;
   
   entity mips is -- single cycle MIPS processor
-    port(clk, reset:        in  STD_LOGIC;
-         pc:                out STD_LOGIC_VECTOR(31 downto 0);
-         instr:             in  STD_LOGIC_VECTOR(31 downto 0);
-         memwrite:          out STD_LOGIC;
-         aluout, writedata: out STD_LOGIC_VECTOR(31 downto 0);
-         ula_source_1, ula_source_2:   in STD_LOGIC_VECTOR(31 downto 0);
-         readdata:          in  STD_LOGIC_VECTOR(31 downto 0));
+    port(clk, reset:                 in  STD_LOGIC;
+         pc:                         out STD_LOGIC_VECTOR(31 downto 0);
+         instr_A, instr_B, instr_C:  in  STD_LOGIC_VECTOR(31 downto 0);
+         memwrite:                   out STD_LOGIC;
+         aluout, writedata:          out STD_LOGIC_VECTOR(31 downto 0);
+         ula_source_1, ula_source_2: in STD_LOGIC_VECTOR(31 downto 0);
+         readdata:                   in  STD_LOGIC_VECTOR(31 downto 0));
   end;
   
   architecture struct of mips is
     component controller
-      port(op, funct:          in  STD_LOGIC_VECTOR(5 downto 0);
+      port(op_A, funct_A:      in  STD_LOGIC_VECTOR(5 downto 0);
+           op_B, funct_B:      in  STD_LOGIC_VECTOR(5 downto 0);
+           op_C, funct_C:      in  STD_LOGIC_VECTOR(5 downto 0);
            zero:               in  STD_LOGIC;
            memtoreg, memwrite: out STD_LOGIC;
            pcsrc, alusrc:      out STD_LOGIC;
@@ -120,7 +125,7 @@ architecture test of testbench is
            alucontrol:        in  STD_LOGIC_VECTOR(2 downto 0);
            zero:              out STD_LOGIC;
            pc:                buffer STD_LOGIC_VECTOR(31 downto 0);
-           instr:             in STD_LOGIC_VECTOR(31 downto 0);
+           instr_A, instr_B, instr_C:             in STD_LOGIC_VECTOR(31 downto 0);
            aluout: buffer STD_LOGIC_VECTOR(31 downto 0);
            ula_source_1:          in  STD_LOGIC_VECTOR(31 downto 0);
            ula_source_2:          in  STD_LOGIC_VECTOR(31 downto 0));
@@ -129,10 +134,12 @@ architecture test of testbench is
     signal zero: STD_LOGIC;
     signal alucontrol: STD_LOGIC_VECTOR(2 downto 0);
   begin
-    cont: controller port map(instr(31 downto 26), instr(5 downto 0),
+    cont: controller port map(instr_A(31 downto 26), instr_A(5 downto 0),
+                              instr_B(31 downto 26), instr_B(5 downto 0),
+                              instr_C(31 downto 26), instr_C(5 downto 0),
                               zero, memtoreg, memwrite, pcsrc, alusrc,
                               regdst, regwrite, jump, alucontrol);
     dp: datapath port map(clk, reset, memtoreg, pcsrc, alusrc, regdst,
-                          jump, alucontrol, zero, pc, instr,
+                          jump, alucontrol, zero, pc, instr_A, instr_B, instr_C,
                           aluout, ula_source_1, ula_source_2);
   end;


### PR DESCRIPTION
removes the register file from the original MIPS Single Datapath and tries to set all the necessary signals that need  to be added because of this change.

As of the last commit, Model Sim is compiling and showing the signals